### PR TITLE
Add ArrayBuffer support

### DIFF
--- a/example/engine_template.html
+++ b/example/engine_template.html
@@ -202,10 +202,13 @@
 			JsToDef.send("ObjectEvent", {foo:"bar", num:16});
 			JsToDef.send("FloatEvent", 19.2);
 			JsToDef.send("IntEvent", 18);
-			JsToDef.send("StrintEvent", "str");
+			JsToDef.send("StringEvent", "str");
+			JsToDef.send("NullStringEvent", "str\0str");
 			JsToDef.send("EmptyEvent");
 			JsToDef.send("BooleanEvent", true);
 			JsToDef.send("BooleanEvent", false);
+			JsToDef.send("Uint8ArrayEvent", new Uint8Array([68, 101, 102, 111, 108, 100]));
+			JsToDef.send("ArrayBufferEvent", (new Uint8Array([78, 117, 108, 108, 0, 84, 101, 115, 116])).buffer);
 		}, 3000)
 	</script>
 </body>

--- a/example/example.script
+++ b/example/example.script
@@ -1,5 +1,9 @@
 local function example_1_listener(self, message_id, message)
-	pprint("example1", message_id, message)
+	if type(message) == "string" then
+		print("example1", message_id, message, "(" .. string.len(message) .. " bytes)")
+	else
+		pprint("example1", message_id, message)
+	end
 end
 
 function init(self)

--- a/example/example_2.script
+++ b/example/example_2.script
@@ -1,5 +1,9 @@
 local function example_2_listener(self, message_id, message)
-	pprint("example2", message_id, message)
+	if type(message) == "string" then
+		print("example2", message_id, message, "(" .. string.len(message) .. " bytes)")
+	else
+		pprint("example2", message_id, message)
+	end
 end
 
 function init(self)

--- a/jstodef/lib/web/lib_jstodef.js
+++ b/jstodef/lib/web/lib_jstodef.js
@@ -23,15 +23,24 @@ var LibJsToDef = {
                             {{{ makeDynCall("vif", "JsToDef._callback_number")}}}(msg_id, message);
                             break;
                         case 'string':
-                            var msg = allocate(intArrayFromString(message), "i8", ALLOC_NORMAL);
-                            {{{ makeDynCall("vii", "JsToDef._callback_string")}}}(msg_id, msg);
+                            var msg_arr = intArrayFromString(message, true);
+                            var msg = allocate(msg_arr, "i8", ALLOC_NORMAL);
+                            {{{ makeDynCall("viii", "JsToDef._callback_string")}}}(msg_id, msg, msg_arr.length);
                             Module._free(msg);
                             break;
                         case 'object':
-                            var msg = JSON.stringify(message);
-                            msg = allocate(intArrayFromString(msg), "i8", ALLOC_NORMAL);
-                            {{{ makeDynCall("vii"," JsToDef._callback_object")}}}(msg_id, msg);
-                            Module._free(msg);
+                            if (message instanceof ArrayBuffer || ArrayBuffer.isView(message)) {
+                                var msg_arr = new Uint8Array(ArrayBuffer.isView(message) ? message.buffer : message);
+                                var msg = allocate(msg_arr, "i8", ALLOC_NORMAL);
+                                {{{ makeDynCall("viii", "JsToDef._callback_string")}}}(msg_id, msg, msg_arr.length);
+                                Module._free(msg);
+                            } else {
+                                var msg = JSON.stringify(message);
+                                var msg_arr = intArrayFromString(msg, true);
+                                msg = allocate(msg_arr, "i8", ALLOC_NORMAL);
+                                {{{ makeDynCall("viii", "JsToDef._callback_object")}}}(msg_id, msg, msg_arr.length);
+                                Module._free(msg);
+                            }
                             break;
                         case 'boolean':
                             var msg = message ? 1 : 0; 

--- a/jstodef/src/jstodef.cpp
+++ b/jstodef/src/jstodef.cpp
@@ -7,7 +7,7 @@
 
 #if defined(DM_PLATFORM_HTML5)
 
-typedef void (*ObjectMessage)(const char* message_id, const char* message);
+typedef void (*ObjectMessage)(const char* message_id, const char* message, const int length);
 typedef void (*NoMessage)(const char* message_id);
 typedef void (*NumberMessage)(const char* message_id, float message);
 typedef void (*BooleanMessage)(const char* message_id, int message);
@@ -63,7 +63,7 @@ static bool check_callback_and_instance(JsToDefListener* cbk)
     return true;
 }
 
-static void JsToDef_SendObjectMessage(const char* message_id, const char* message)
+static void JsToDef_SendObjectMessage(const char* message_id, const char* message, const int length)
 {
     for(int i = m_listeners.Size() - 1; i >= 0; --i)
     {
@@ -79,7 +79,7 @@ static void JsToDef_SendObjectMessage(const char* message_id, const char* messag
             //[-2] - self
             //[-3] - callback
             dmJson::Document doc;
-            dmJson::Result r = dmJson::Parse(message, &doc);
+            dmJson::Result r = dmJson::Parse(message, length, &doc);
             if (r == dmJson::RESULT_OK && doc.m_NodeCount > 0) {
                 char error_str_out[128];
                 if (dmScript::JsonToLua(L, &doc, 0, error_str_out, sizeof(error_str_out)) < 0) {
@@ -110,7 +110,7 @@ static void JsToDef_SendObjectMessage(const char* message_id, const char* messag
     }
 }
 
-static void JsToDef_SendStringMessage(const char* message_id, const char* message)
+static void JsToDef_SendStringMessage(const char* message_id, const char* message, const int length)
 {
     for(int i = m_listeners.Size() - 1; i >= 0; --i)
     {
@@ -122,7 +122,7 @@ static void JsToDef_SendStringMessage(const char* message_id, const char* messag
         int top = lua_gettop(L);
         if (check_callback_and_instance(cbk)) {
             lua_pushstring(L, message_id);
-            lua_pushstring(L, message);
+            lua_pushlstring(L, message, length);
             int ret = lua_pcall(L, 3, 0, 0);
             if(ret != 0) {
                 dmLogError("Error running callback: %s", lua_tostring(L, -1));


### PR DESCRIPTION
This PR adds the ability to send the [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) object to a Defold game. Also, now you can pass strings with the null character.

One of the use cases of this is to implement [a file uploading in HTML5](https://github.com/aglitchman/defold-dmanifest-decode/blob/main/ext/manifests/web/engine_template.html). The real-world example is [this tool](https://aglitchman.github.io/defold-dmanifest-decode/) that I was using to debug Live Update's behaviour.


